### PR TITLE
Upgrade Android Dependencies

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -1,16 +1,17 @@
 apply plugin: 'com.android.application'
 
 android {
-    compileSdkVersion 26
-    buildToolsVersion '27.0.3'
+    compileSdkVersion versions.compileSdk
+
     defaultConfig {
         applicationId "ca.antonious.sampleapp"
-        minSdkVersion 19
-        targetSdkVersion 26
+        minSdkVersion versions.minSdk
+        targetSdkVersion versions.targetSdk
         versionCode 1
         versionName "1.0"
         testInstrumentationRunner "android.support.test.runner.AndroidJUnitRunner"
     }
+
     buildTypes {
         release {
             minifyEnabled false
@@ -23,10 +24,7 @@ dependencies {
     implementation project(":lib")
 
     implementation fileTree(dir: 'libs', include: ['*.jar'])
-    implementation 'com.android.support:appcompat-v7:26.1.0'
-    implementation 'com.android.support.constraint:constraint-layout:1.0.2'
-    testImplementation 'junit:junit:4.12'
-    androidTestImplementation('com.android.support.test.espresso:espresso-core:3.0.1', {
-        exclude group: 'com.android.support', module: 'support-annotations'
-    })
+
+    implementation depends.android.appCompatV7
+    implementation depends.android.constraintLayout
 }

--- a/build.gradle
+++ b/build.gradle
@@ -1,26 +1,44 @@
 // Top-level build file where you can add configuration options common to all sub-projects/modules.
 
 buildscript {
-    
+
     repositories {
         google()
         jcenter()
     }
-    dependencies {
-        classpath 'com.android.tools.build:gradle:3.1.2'
-        classpath 'com.novoda:bintray-release:0.8.0'
 
-        // NOTE: Do not place your application dependencies here; they belong
-        // in the individual module build.gradle files
+    ext {
+        bintray = [
+            'userOrg' : 'gantonious',
+            'groupId' : 'ca.antonious',
+            'publishVersion' : '0.4.0',
+            'website' : "https://github.com/gantonious/MaterialDayPicker"
+        ]
+
+        versions = [
+            'compileSdk' : 28,
+            'targetSdk' : 28,
+            'minSdk' : 19,
+            'bintrayRelease' : '0.8.0',
+            'gradleVersion' : '3.4.0',
+            'android' : [
+                'supportLibary' : '28.0.0',
+                'constraintLayout' : '1.1.0'
+            ]
+        ]
+
+        depends = [
+            'android' : [
+                'appCompatV7' : "com.android.support:appcompat-v7:$versions.android.supportLibary",
+                'constraintLayout' : "com.android.support.constraint:constraint-layout:${versions.android.constraintLayout}"
+            ]
+        ]
     }
-}
 
-
-ext {
-    userOrg = 'gantonious'
-    groupId = 'ca.antonious'
-    publishVersion = '0.4.0'
-    website = "https://github.com/gantonious/MaterialDayPicker"
+    dependencies {
+        classpath "com.android.tools.build:gradle:${versions.gradleVersion}"
+        classpath "com.novoda:bintray-release:${versions.bintrayRelease}"
+    }
 }
 
 

--- a/circle.yml
+++ b/circle.yml
@@ -1,7 +1,6 @@
 dependencies:
   pre:
-    - echo y | android update sdk --no-ui --filter "android-26"
-    - echo y | android update sdk --no-ui --all --filter "build-tools-27.0.3"
+    - echo y | android update sdk --no-ui --filter "android-28"
 
 deployment:
   production:

--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -3,4 +3,4 @@ distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-4.4-all.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-5.1.1-all.zip

--- a/lib/build.gradle
+++ b/lib/build.gradle
@@ -2,13 +2,11 @@ apply plugin: 'com.android.library'
 apply plugin: 'com.novoda.bintray-release'
 
 android {
-    compileSdkVersion 26
-    buildToolsVersion '27.0.3'
-
+    compileSdkVersion versions.compileSdk
 
     defaultConfig {
-        minSdkVersion 19
-        targetSdkVersion 26
+        minSdkVersion versions.minSdk
+        targetSdkVersion versions.targetSdk
         versionCode 1
         versionName "1.0"
         testInstrumentationRunner "android.support.test.runner.AndroidJUnitRunner"
@@ -25,18 +23,13 @@ android {
 
 dependencies {
     implementation fileTree(dir: 'libs', include: ['*.jar'])
-    implementation 'com.android.support:appcompat-v7:26.1.0'
-    testImplementation 'junit:junit:4.12'
-    androidTestImplementation('com.android.support.test.espresso:espresso-core:3.0.1', {
-        exclude group: 'com.android.support', module: 'support-annotations'
-    })
-
+    implementation depends.android.appCompatV7
 }
 
 publish {
-    userOrg = rootProject.ext.userOrg
-    groupId = rootProject.ext.groupId
+    userOrg = bintray.userOrg
+    groupId = bintray.groupId
     artifactId = 'materialdaypicker'
-    publishVersion = rootProject.ext.publishVersion
-    website = rootProject.ext.website
+    publishVersion = bintray.publishVersion
+    website = bintray.website
 }


### PR DESCRIPTION
Upgrade android dependencies to API 28 and refactor project structure to define all dependencies in root project.

Resolves https://github.com/gantonious/MaterialDayPicker/issues/11