### PR TITLE
Resolve day abbreviation using java.time on API 26+

### DIFF
--- a/lib/src/main/res/layout/day_of_the_week_picker.xml
+++ b/lib/src/main/res/layout/day_of_the_week_picker.xml
@@ -8,9 +8,7 @@
 
     <ToggleButton
         android:id="@+id/sunday_toggle"
-        style="@style/MaterialDayPickerToggle"
-        android:textOn="@string/sunday_abbreviation"
-        android:textOff="@string/sunday_abbreviation"/>
+        style="@style/MaterialDayPickerToggle"/>
 
     <View
         android:layout_width="wrap_content"
@@ -19,9 +17,7 @@
 
     <ToggleButton
         android:id="@+id/monday_toggle"
-        style="@style/MaterialDayPickerToggle"
-        android:textOn="@string/monday_abbreviation"
-        android:textOff="@string/monday_abbreviation"/>
+        style="@style/MaterialDayPickerToggle"/>
 
     <View
         android:layout_width="wrap_content"
@@ -31,9 +27,7 @@
 
     <ToggleButton
         android:id="@+id/tuesday_toggle"
-        style="@style/MaterialDayPickerToggle"
-        android:textOn="@string/tuesday_abbreviation"
-        android:textOff="@string/tuesday_abbreviation"/>
+        style="@style/MaterialDayPickerToggle"/>
 
     <View
         android:layout_width="wrap_content"
@@ -42,9 +36,7 @@
 
     <ToggleButton
         android:id="@+id/wednesday_toggle"
-        style="@style/MaterialDayPickerToggle"
-        android:textOn="@string/wednesday_abbreviation"
-        android:textOff="@string/wednesday_abbreviation" />
+        style="@style/MaterialDayPickerToggle"/>
 
     <View
         android:layout_width="wrap_content"
@@ -54,9 +46,7 @@
 
     <ToggleButton
         android:id="@+id/thursday_toggle"
-        style="@style/MaterialDayPickerToggle"
-        android:textOn="@string/thursday_abbreviation"
-        android:textOff="@string/thursday_abbreviation"/>
+        style="@style/MaterialDayPickerToggle"/>
 
     <View
         android:layout_width="wrap_content"
@@ -65,9 +55,7 @@
 
     <ToggleButton
         android:id="@+id/friday_toggle"
-        style="@style/MaterialDayPickerToggle"
-        android:textOn="@string/friday_abbreviation"
-        android:textOff="@string/friday_abbreviation"/>
+        style="@style/MaterialDayPickerToggle"/>
 
     <View
         android:layout_width="wrap_content"
@@ -76,7 +64,5 @@
 
     <ToggleButton
         android:id="@+id/saturday_toggle"
-        style="@style/MaterialDayPickerToggle"
-        android:textOn="@string/saturday_abbreviation"
-        android:textOff="@string/saturday_abbreviation"/>
+        style="@style/MaterialDayPickerToggle"/>
 </LinearLayout>


### PR DESCRIPTION
### What does this change accomplish?

`java.time` can return the the one letter abbreviation we wan't to render for different locales. Sadly this is supported only on API 26+. We can use this in combination with strings.xml fallbacks for older APIs.

Should look into a way to do this without `java.time`. Maybe we can formulate a `DateTimeFormat` that properly formats the day of the week.

Resolves https://github.com/gantonious/MaterialDayPicker/issues/20