### PR TITLE
Use SimpleDateFormat to get day abbreviations and remove translated strings

### DIFF
--- a/lib/src/main/java/ca/antonious/materialdaypicker/MaterialDayPicker.kt
+++ b/lib/src/main/java/ca/antonious/materialdaypicker/MaterialDayPicker.kt
@@ -1,14 +1,12 @@
 package ca.antonious.materialdaypicker
 
-import android.annotation.TargetApi
 import android.content.Context
-import android.os.Build
 import android.util.AttributeSet
 import android.view.LayoutInflater
 import android.widget.LinearLayout
 import android.widget.ToggleButton
-import java.time.DayOfWeek
-import java.time.format.TextStyle
+import java.text.SimpleDateFormat
+import java.util.Calendar
 import java.util.Locale
 import kotlinx.android.synthetic.main.day_of_the_week_picker.view.friday_toggle
 import kotlinx.android.synthetic.main.day_of_the_week_picker.view.monday_toggle
@@ -27,7 +25,11 @@ import kotlinx.android.synthetic.main.day_of_the_week_picker.view.wednesday_togg
  *     daySelected - the color when a day is selected
  *     dayDeselected - the color when a day is deselected
  */
-class MaterialDayPicker @JvmOverloads constructor(context: Context, attrs: AttributeSet? = null, defStyleAttr: Int = 0) : LinearLayout(context, attrs, defStyleAttr) {
+class MaterialDayPicker @JvmOverloads constructor(
+    context: Context,
+    attrs: AttributeSet? = null,
+    defStyleAttr: Int = 0
+) : LinearLayout(context, attrs, defStyleAttr) {
 
     /**
      * Gets/sets the current [DayPressedListener].
@@ -192,8 +194,8 @@ class MaterialDayPicker @JvmOverloads constructor(context: Context, attrs: Attri
     }
 
     private fun ToggleButton.withLocalizedLabel(weekday: Weekday): ToggleButton {
-        textOn = weekday.getAbbreviation(context)
-        textOff = weekday.getAbbreviation(context)
+        textOn = weekday.abbreviation
+        textOff = weekday.abbreviation
         // setting textOn/textOff doesn't force a redraw so we just set
         // isChecked to its current value
         isChecked = isChecked
@@ -306,49 +308,28 @@ class MaterialDayPicker @JvmOverloads constructor(context: Context, attrs: Attri
          * i.e. In an english based locale:
          *
          * ```kotlin
-         *     Weekday.MONDAY.getAbbreviation(context) == "M"
-         *     Weekday.THURSDAY.getAbbreviation(context) == "T"
+         *     Weekday.MONDAY.abbreviation == "M"
+         *     Weekday.THURSDAY.abbreviation == "T"
          * ```
-         *
-         * @param context context used to resolve the abbreviation
-         * @return An abbreviated representation of [Weekday] based on the current Locale
          */
-        fun getAbbreviation(context: Context): String {
-            return if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.O) {
-                localizeDayOfWeekUsingJavaTime()
-            } else {
-                localizeDayUsingTranslatedStrings(context)
+        val abbreviation: String
+            get() {
+                val dayOfWeek = when (this) {
+                    SUNDAY -> Calendar.SUNDAY
+                    MONDAY -> Calendar.MONDAY
+                    TUESDAY -> Calendar.TUESDAY
+                    WEDNESDAY -> Calendar.WEDNESDAY
+                    THURSDAY -> Calendar.THURSDAY
+                    FRIDAY -> Calendar.FRIDAY
+                    SATURDAY -> Calendar.SATURDAY
+                }
+
+                val calendar = Calendar.getInstance().apply {
+                    set(Calendar.DAY_OF_WEEK, dayOfWeek)
+                }
+
+                return SimpleDateFormat("EEEEE", Locale.getDefault()).format(calendar.time)
             }
-        }
-
-        private fun localizeDayUsingTranslatedStrings(context: Context): String {
-            val stringRes = when (this) {
-                SUNDAY -> R.string.sunday_abbreviation
-                MONDAY -> R.string.monday_abbreviation
-                TUESDAY -> R.string.tuesday_abbreviation
-                WEDNESDAY -> R.string.wednesday_abbreviation
-                THURSDAY -> R.string.thursday_abbreviation
-                FRIDAY -> R.string.friday_abbreviation
-                SATURDAY -> R.string.saturday_abbreviation
-            }
-
-            return context.getString(stringRes)
-        }
-
-        @TargetApi(Build.VERSION_CODES.O)
-        private fun localizeDayOfWeekUsingJavaTime(): String {
-            val dayOfWeek = when (this) {
-                SUNDAY -> DayOfWeek.SUNDAY
-                MONDAY -> DayOfWeek.MONDAY
-                TUESDAY -> DayOfWeek.TUESDAY
-                WEDNESDAY -> DayOfWeek.WEDNESDAY
-                THURSDAY -> DayOfWeek.THURSDAY
-                FRIDAY -> DayOfWeek.FRIDAY
-                SATURDAY -> DayOfWeek.SATURDAY
-            }
-
-            return dayOfWeek.getDisplayName(TextStyle.NARROW, Locale.getDefault())
-        }
 
         companion object {
             operator fun get(index: Int): Weekday {

--- a/lib/src/main/res/values-es/strings.xml
+++ b/lib/src/main/res/values-es/strings.xml
@@ -1,9 +1,0 @@
-<resources>
-    <string name="sunday_abbreviation">D</string>
-    <string name="monday_abbreviation">L</string>
-    <string name="tuesday_abbreviation">M</string>
-    <string name="wednesday_abbreviation">M</string>
-    <string name="thursday_abbreviation">J</string>
-    <string name="friday_abbreviation">V</string>
-    <string name="saturday_abbreviation">S</string>
-</resources>

--- a/lib/src/main/res/values-fr/strings.xml
+++ b/lib/src/main/res/values-fr/strings.xml
@@ -1,9 +1,0 @@
-<resources>
-    <string name="sunday_abbreviation">D</string>
-    <string name="monday_abbreviation">L</string>
-    <string name="tuesday_abbreviation">M</string>
-    <string name="wednesday_abbreviation">M</string>
-    <string name="thursday_abbreviation">J</string>
-    <string name="friday_abbreviation">V</string>
-    <string name="saturday_abbreviation">S</string>
-</resources>

--- a/lib/src/main/res/values-hi/strings.xml
+++ b/lib/src/main/res/values-hi/strings.xml
@@ -1,9 +1,0 @@
-<resources>
-    <string name="sunday_abbreviation">र</string>
-    <string name="monday_abbreviation">सो</string>
-    <string name="tuesday_abbreviation">मं</string>
-    <string name="wednesday_abbreviation">बु</string>
-    <string name="thursday_abbreviation">गु</string>
-    <string name="friday_abbreviation">शु</string>
-    <string name="saturday_abbreviation">श</string>
-</resources>

--- a/lib/src/main/res/values-it/strings.xml
+++ b/lib/src/main/res/values-it/strings.xml
@@ -1,9 +1,0 @@
-<resources>
-    <string name="sunday_abbreviation">D</string>
-    <string name="monday_abbreviation">L</string>
-    <string name="tuesday_abbreviation">M</string>
-    <string name="wednesday_abbreviation">M</string>
-    <string name="thursday_abbreviation">G</string>
-    <string name="friday_abbreviation">V</string>
-    <string name="saturday_abbreviation">S</string>
-</resources>

--- a/lib/src/main/res/values-ja/strings.xml
+++ b/lib/src/main/res/values-ja/strings.xml
@@ -1,9 +1,0 @@
-<resources>
-    <string name="sunday_abbreviation">日</string>
-    <string name="monday_abbreviation">月</string>
-    <string name="tuesday_abbreviation">火</string>
-    <string name="wednesday_abbreviation">水</string>
-    <string name="thursday_abbreviation">木</string>
-    <string name="friday_abbreviation">金</string>
-    <string name="saturday_abbreviation">土</string>
-</resources>

--- a/lib/src/main/res/values-pt/strings.xml
+++ b/lib/src/main/res/values-pt/strings.xml
@@ -1,9 +1,0 @@
-<resources>
-    <string name="sunday_abbreviation">D</string>
-    <string name="monday_abbreviation">S</string>
-    <string name="tuesday_abbreviation">T</string>
-    <string name="wednesday_abbreviation">Q</string>
-    <string name="thursday_abbreviation">Q</string>
-    <string name="friday_abbreviation">S</string>
-    <string name="saturday_abbreviation">S</string>
-</resources>

--- a/lib/src/main/res/values-ru/strings.xml
+++ b/lib/src/main/res/values-ru/strings.xml
@@ -1,9 +1,0 @@
-<resources>
-    <string name="sunday_abbreviation">в</string>
-    <string name="monday_abbreviation">п</string>
-    <string name="tuesday_abbreviation">в</string>
-    <string name="wednesday_abbreviation">с</string>
-    <string name="thursday_abbreviation">ч</string>
-    <string name="friday_abbreviation">п</string>
-    <string name="saturday_abbreviation">с</string>
-</resources>

--- a/lib/src/main/res/values-zh/strings.xml
+++ b/lib/src/main/res/values-zh/strings.xml
@@ -1,9 +1,0 @@
-<resources>
-    <string name="sunday_abbreviation">日</string>
-    <string name="monday_abbreviation">一</string>
-    <string name="tuesday_abbreviation">二</string>
-    <string name="wednesday_abbreviation">三</string>
-    <string name="thursday_abbreviation">四</string>
-    <string name="friday_abbreviation">五</string>
-    <string name="saturday_abbreviation">六</string>
-</resources>

--- a/lib/src/main/res/values/strings.xml
+++ b/lib/src/main/res/values/strings.xml
@@ -1,9 +1,0 @@
-<resources>
-    <string name="sunday_abbreviation">S</string>
-    <string name="monday_abbreviation">M</string>
-    <string name="tuesday_abbreviation">T</string>
-    <string name="wednesday_abbreviation">W</string>
-    <string name="thursday_abbreviation">T</string>
-    <string name="friday_abbreviation">F</string>
-    <string name="saturday_abbreviation">S</string>
-</resources>


### PR DESCRIPTION
### What does this change accomplish?

Resolves https://github.com/gantonious/MaterialDayPicker/issues/37
