### PR TITLE
Scale day abbreviation size down for abbreviations longer than button width

### DIFF
--- a/lib/src/main/res/values/dimens.xml
+++ b/lib/src/main/res/values/dimens.xml
@@ -1,0 +1,5 @@
+<?xml version="1.0" encoding="utf-8"?>
+<resources>
+    <dimen name="day_button_size">40dp</dimen>
+    <dimen name="day_button_max_font_size">22sp</dimen>
+</resources>

--- a/lib/src/main/res/values/styles.xml
+++ b/lib/src/main/res/values/styles.xml
@@ -1,10 +1,10 @@
 <?xml version="1.0" encoding="utf-8"?>
 <resources>
     <style name="MaterialDayPickerToggle" parent="@style/Widget.AppCompat.Button.Borderless">
-        <item name="android:layout_width">40dp</item>
-        <item name="android:layout_height">40dp</item>
+        <item name="android:layout_width">@dimen/day_button_size</item>
+        <item name="android:layout_height">@dimen/day_button_size</item>
         <item name="android:background">@drawable/circle_toggle_button</item>
-        <item name="android:textSize">22sp</item>
+        <item name="android:textSize">@dimen/day_button_max_font_size</item>
         <item name="android:textColor">@color/circle_toggle_button_text_color</item>
         <item name="android:textAllCaps">false</item>
     </style>


### PR DESCRIPTION
### What does this change accomplish?

Resolves https://github.com/gantonious/MaterialDayPicker/issues/43

|Before Scaling|After Scaling|
|---|---|
|![image](https://user-images.githubusercontent.com/9062713/66892259-40672300-efb9-11e9-87db-dec7f7444ba2.png)|![image](https://user-images.githubusercontent.com/9062713/66892261-43621380-efb9-11e9-9870-3d53677f13ab.png)|