### PR TITLE
Fixes an issue where calling setSelectedDays would cause selected days to flash off and on.

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,7 +15,12 @@ Inspired by the day picker in the builtin Android clock app:
 - 🌎 Fully localized
 - 👻 Supports dark mode
 
-## What's New: Version 0.7.0 - Better Configuration
+## What's New: Version 0.7.1 - Better Configuration + Bug fixes
+
+**Bug fixes**
+- Fixes an issue where calling `setSelectedDays` would cause selected days to flash off and on.
+
+### Changes from 0.7.0
 
 **Configuration Improvements**
 - You can now enable/disable days from being selected using enableDay/disableDay methods. See more below.
@@ -25,7 +30,7 @@ Download the latest version by adding the following to your project's `build.gra
 
 ```groovy
 dependencies {
-    implementation 'ca.antonious:materialdaypicker:0.7.0'
+    implementation 'ca.antonious:materialdaypicker:0.7.1'
 }
 ```
 

--- a/build.gradle
+++ b/build.gradle
@@ -11,7 +11,7 @@ buildscript {
         bintray = [
             'userOrg' : 'gantonious',
             'groupId' : 'ca.antonious',
-            'publishVersion' : '0.7.0',
+            'publishVersion' : '0.7.1',
             'website' : "https://github.com/gantonious/MaterialDayPicker"
         ]
 

--- a/lib/src/main/java/ca/antonious/materialdaypicker/MaterialDayPicker.kt
+++ b/lib/src/main/java/ca/antonious/materialdaypicker/MaterialDayPicker.kt
@@ -200,10 +200,12 @@ class MaterialDayPicker @JvmOverloads constructor(
      * @param weekdays days to select
      */
     fun setSelectedDays(weekdays: List<Weekday>) {
-        disableListenerWhileExecuting {
-            clearSelection()
-            weekdays.forEach { selectDay(it) }
-        }
+        val selectionDifference = selectionDifferenceOf(
+            initialSelectionState = SelectionState(selectedDays),
+            finalSelectionState = SelectionState(weekdays)
+        )
+
+        applySelectionChangesUsing(selectionDifference)
     }
 
     /**


### PR DESCRIPTION
### What does this change accomplish?

Now we take the diff of the current state and the new selections passed into `setSelectedDays` and only apply the differences. This way days already selected are not deselected then selected.

Resolves https://github.com/gantonious/MaterialDayPicker/issues/55
