### PR TITLE
Release MaterialDayPicker 0.7.3

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,7 +15,11 @@ Inspired by the day picker in the builtin Android clock app:
 - 🌎 Fully localized
 - 👻 Supports dark mode
 
-## What's New: Version 0.7.2 - Better Configuration + Bug fixes
+## What's New: Version 0.7.3 - Better Configuration + Bug fixes
+
+- Upgraded MaterialDayPicker to target API 30 and upgraded its AndroidX dependencies
+
+### Changes from 0.7.2
 
 **Bug fixes**
 - Fixes a bug when using android gradle plugin `3.6.1` that would cause building to fail due to not being able to find the `selectionMode` attribute.
@@ -35,7 +39,7 @@ Download the latest version by adding the following to your project's `build.gra
 
 ```groovy
 dependencies {
-    implementation 'ca.antonious:materialdaypicker:0.7.2'
+    implementation 'ca.antonious:materialdaypicker:0.7.3'
 }
 ```
 

--- a/build.gradle
+++ b/build.gradle
@@ -11,7 +11,7 @@ buildscript {
         bintray = [
             'userOrg' : 'gantonious',
             'groupId' : 'ca.antonious',
-            'publishVersion' : '0.7.2',
+            'publishVersion' : '0.7.3',
             'website' : "https://github.com/gantonious/MaterialDayPicker"
         ]
 

--- a/build.gradle
+++ b/build.gradle
@@ -16,8 +16,8 @@ buildscript {
         ]
 
         versions = [
-            'compileSdk' : 29,
-            'targetSdk' : 29,
+            'compileSdk' : 30,
+            'targetSdk' : 30,
             'minSdk' : 19,
             'kotlin' : '1.3.61',
             'ktlint' : '0.36.0',
@@ -28,9 +28,10 @@ buildscript {
             ],
             // https://developer.android.com/jetpack/androidx/versions
             'androidx' : [
-                'appCompat' : '1.1.0',
-                'ktx': '1.1.0',
-                'constraintLayout' : '1.1.3'
+                'appCompat' : '1.2.0',
+                'ktx': '1.3.2',
+                'constraintLayout' : '2.0.2',
+                'core' : '1.3.2'
             ]
         ]
 
@@ -43,7 +44,8 @@ buildscript {
             'androidx' : [
                 'appCompatV7' : "androidx.appcompat:appcompat:${versions.androidx.appCompat}",
                 'ktx' : "androidx.core:core-ktx:${versions.androidx.ktx}",
-                'constraintLayout' : "androidx.constraintlayout:constraintlayout:${versions.androidx.constraintLayout}"
+                'constraintLayout' : "androidx.constraintlayout:constraintlayout:${versions.androidx.constraintLayout}",
+                'core' : "androidx.core:core:${versions.androidx.core}"
             ]
         ]
 

--- a/lib/build.gradle
+++ b/lib/build.gradle
@@ -30,6 +30,7 @@ dependencies {
     implementation depends.kotlin.stdlib
     implementation depends.androidx.ktx
     implementation depends.androidx.appCompatV7
+    implementation depends.androidx.core
 
     testImplementation depends.junit
 }


### PR DESCRIPTION
```
- Upgraded MaterialDayPicker to target API 30 and upgraded its AndroidX dependencies
```